### PR TITLE
Update ccspi.h

### DIFF
--- a/ccspi.h
+++ b/ccspi.h
@@ -54,7 +54,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <Spi.h>
+#include <SPI.h>
 
 #include "utility/wlan.h"
 


### PR DESCRIPTION
Spi.h should be SPI.h

Fails to find "Spi.h" on case sensitive file systems.
