### PR TITLE
Update debug.h

### DIFF
--- a/utility/debug.h
+++ b/utility/debug.h
@@ -23,6 +23,11 @@
 
 #include <Arduino.h>
 
+#define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#if (GCC_VERSION >= 40702)
+typedef char PROGMEM prog_char;
+#endif
+
 #ifndef _CC3000_DEBUG
 #define _CC3000_DEBUG
 


### PR DESCRIPTION
The prog_char type was replaced by PROGMEM in  avr-gcc  version 4.7.2 or possibly before then. 

I see prog_char undefined in Arduino IDE 1.0.3. 

I see prog_char defined in Arduino IDE 1.0
