### PR TITLE
Support Teensy 3.0 & ARM, plus minor const pointer fix

### DIFF
--- a/Adafruit_CC3000.cpp
+++ b/Adafruit_CC3000.cpp
@@ -774,7 +774,7 @@ bool Adafruit_CC3000::startSmartConfig(bool enableAES)
     @returns  False if an error occured!
 */
 /**************************************************************************/
-bool Adafruit_CC3000::connectOpen(char *ssid)
+bool Adafruit_CC3000::connectOpen(const char *ssid)
 {
   if (!_initialised) {
     return false;
@@ -785,7 +785,7 @@ bool Adafruit_CC3000::connectOpen(char *ssid)
                  "Failed to set connection policy", false);
     delay(500);
     CHECK_SUCCESS(wlan_connect(WLAN_SEC_UNSEC,
-			       (char*)ssid, strlen(ssid),
+			       (const char*)ssid, strlen(ssid),
 			       0 ,NULL,0),
                   "SSID connection failed", false);
   #else
@@ -866,7 +866,7 @@ void CC3000_UsynchCallback(long lEventType, char * data, unsigned char length)
 */
 /**************************************************************************/
 #ifndef CC3000_TINY_DRIVER
-bool Adafruit_CC3000::connectSecure(char *ssid, char *key, int32_t secMode)
+bool Adafruit_CC3000::connectSecure(const char *ssid, const char *key, int32_t secMode)
 {
   int8_t  _key[MAXLENGTHKEY];
   uint8_t _ssid[MAXSSID];
@@ -908,7 +908,7 @@ bool Adafruit_CC3000::connectSecure(char *ssid, char *key, int32_t secMode)
 #endif
 
 // Connect with timeout
-void Adafruit_CC3000::connectToAP(char *ssid, char *key, uint8_t secmode) {
+void Adafruit_CC3000::connectToAP(const char *ssid, const char *key, uint8_t secmode) {
   int16_t timer = WLAN_CONNECT_TIMEOUT;
 
   do {  

--- a/Adafruit_CC3000.h
+++ b/Adafruit_CC3000.h
@@ -101,9 +101,9 @@ class Adafruit_CC3000 {
     bool     getMacAddress(uint8_t address[6]);
     bool     setMacAddress(uint8_t address[6]);
 
-    void     connectToAP(char *ssid, char *key, uint8_t secmode);
-    bool     connectSecure(char *ssid, char *key, int32_t secMode);
-    bool     connectOpen(char *ssid); 
+    void     connectToAP(const char *ssid, const char *key, uint8_t secmode);
+    bool     connectSecure(const char *ssid, const char *key, int32_t secMode);
+    bool     connectOpen(const char *ssid); 
     bool     checkConnected(void);
     bool     checkDHCP(void);
     bool     getIPAddress(uint32_t *retip, uint32_t *netmask, uint32_t *gateway, uint32_t *dhcpserv, uint32_t *dnsserv);

--- a/utility/sntp.cpp
+++ b/utility/sntp.cpp
@@ -7,7 +7,7 @@
 //Lists of pool servers
 
 
-char* ntp_us_pool_list[] =  {	"0.us.pool.ntp.org",
+const char* ntp_us_pool_list[] =  {	"0.us.pool.ntp.org",
 								"1.us.pool.ntp.org",
 								"2.us.pool.ntp.org",
 								"3.us.pool.ntp.org",
@@ -18,7 +18,7 @@ char* ntp_us_pool_list[] =  {	"0.us.pool.ntp.org",
 								NULL
 							};
 
-char* ntp_global_pool_list[] =  {   "0.pool.ntp.org",
+const char* ntp_global_pool_list[] =  {   "0.pool.ntp.org",
 									"1.pool.ntp.org",
 									"2.pool.ntp.org",
 									"pool.ntp.org",
@@ -353,10 +353,10 @@ sntp::sntp(char* ntp_server_url1, short local_utc_offset, short dst_utc_offset, 
 //To spread the load of NTP client request, ntp.org maintains DNS servers that will return a list of
 // available NTP servers from a pool.  This routine gets a list of servers from the specified pool
 // and returns it, along with a count of the servers in the list.
-char sntp::GetNTPServerList(char** ntp_pool_list, uint32_t* addrBuffer, int maxServerCount)
+char sntp::GetNTPServerList(const char** ntp_pool_list, uint32_t* addrBuffer, int maxServerCount)
 {
 	uint32_t			 ntpServer= NULL;
-	char               **ntpPoolName;
+	const char           **ntpPoolName;
 	uint8_t              serverCount = 0;
 
 	if ((ntp_pool_list) && (addrBuffer))

--- a/utility/sntp.h
+++ b/utility/sntp.h
@@ -335,7 +335,7 @@ typedef struct SNTP_Message_t
 	//   uint8_t                messageDigest[128];   //optional field - ignore
 }SNTP_Message_t;
 
-typedef char** NTP_Pool_t;								//Name of NTP server pool
+typedef const char** NTP_Pool_t;							//Name of NTP server pool
 typedef uint32_t  NTP_Server_List_t[MAX_NTP_SERVERS];   //list of ntp server addresses (as returned by NTP server pool)
 
 /**
@@ -376,7 +376,7 @@ class sntp
 	int					GetSystemClockAsNTPTime(SNTP_Timestamp_t* ntpSystemTime);
 	
   private:
-	char				GetNTPServerList(char** ntp_pool_list, uint32_t* addrBuffer, int maxServerCount);
+	char				GetNTPServerList(const char** ntp_pool_list, uint32_t* addrBuffer, int maxServerCount);
 	bool				SNTP_GetTime(int sntpSocket, uint32_t *ntpServerAddr);
 
 	NetTime_t			m_timeStruct;
@@ -395,7 +395,7 @@ class sntp
 	NTP_Pool_t			m_localPool;					//list of pool servers for current geographical location
 	NTP_Pool_t			m_globalPool;					//list of global pool servers if no local servers respond
 	uint8_t				m_userServerCount;				//number of NTP servers provded by user (not pool servers)
-	char*				m_userServers[MAX_NTP_SERVERS];	//list of NTP or NTP pool servers provided by user (pointers to userServerStrings)
+	const char*			m_userServers[MAX_NTP_SERVERS];	//list of NTP or NTP pool servers provided by user (pointers to userServerStrings)
 	char				m_userServerStrings[MAX_NTP_SERVERS][MAX_URL_NAME+1]; //storage for user's NTP server URL strings
 
     bool				m_timeIsSet;					//false = current time is not set

--- a/utility/socket.cpp
+++ b/utility/socket.cpp
@@ -469,7 +469,7 @@ listen(long sd, long backlog)
 
 #ifndef CC3000_TINY_DRIVER
 int 
-gethostbyname(char * hostname, uint8_t usNameLen, uint32_t * out_ip_addr)
+gethostbyname(const char * hostname, uint8_t usNameLen, uint32_t * out_ip_addr)
 {
 	tBsdGethostbynameParams ret;
 	unsigned char *ptr, *args;

--- a/utility/socket.h
+++ b/utility/socket.h
@@ -373,7 +373,7 @@ extern long listen(long sd, long backlog);
 //
 //*****************************************************************************
 #ifndef CC3000_TINY_DRIVER 
-extern int gethostbyname(char * hostname, uint8_t usNameLen, uint32_t* out_ip_addr);
+extern int gethostbyname(const char * hostname, uint8_t usNameLen, uint32_t* out_ip_addr);
 #endif
 
 

--- a/utility/wlan.cpp
+++ b/utility/wlan.cpp
@@ -386,7 +386,7 @@ wlan_stop(void)
   
 #ifndef CC3000_TINY_DRIVER
 long
-wlan_connect(unsigned long ulSecType, char *ssid, long ssid_len,
+wlan_connect(unsigned long ulSecType, const char *ssid, long ssid_len,
              unsigned char *bssid, unsigned char *key, long key_len)
 {
 	long ret;
@@ -435,7 +435,7 @@ wlan_connect(unsigned long ulSecType, char *ssid, long ssid_len,
 }
 #else
 long
-wlan_connect(char *ssid, long ssid_len)
+wlan_connect(const char *ssid, long ssid_len)
 {
 	long ret;
 	unsigned char *ptr;

--- a/utility/wlan.h
+++ b/utility/wlan.h
@@ -205,10 +205,10 @@ extern void wlan_stop(void);
 //
 //*****************************************************************************
 #ifndef CC3000_TINY_DRIVER
-extern long wlan_connect(unsigned long ulSecType, char *ssid, long ssid_len,
+extern long wlan_connect(unsigned long ulSecType, const char *ssid, long ssid_len,
                         unsigned char *bssid, unsigned char *key, long key_len);
 #else
-extern long wlan_connect(char *ssid, long ssid_len);
+extern long wlan_connect(const char *ssid, long ssid_len);
 
 #endif
 


### PR DESCRIPTION
This pull request has 3 types of changes.

1: Workarounds for conflicts with newlib C library, used on ARM-based boards (2 commits)
2: Add Teensy to interrupt pin mapping array
3: Fix pointers to constant strings with "const" qualifier

These are made in separate commits.

These changes have been verified to work, and they have also been verified on an Arduino Uno board to not break the library for normal AVR-based Arduino.

http://forum.pjrc.com/threads/23954-WiFi-module-with-an-SPI-interface-project?p=34906&viewfull=1#post34906
