### PR TITLE
Add include guards to header file

### DIFF
--- a/Adafruit_CC3000.h
+++ b/Adafruit_CC3000.h
@@ -17,6 +17,9 @@
 */
 /**************************************************************************/
 
+#ifndef ADAFRUIT_CC3000_H
+#define ADAFRUIT_CC3000_H
+
 #if ARDUINO >= 100
  #include "Arduino.h"
 #else
@@ -143,3 +146,5 @@ class Adafruit_CC3000 {
 };
 
 extern Print* CC3KPrinter;
+
+#endif


### PR DESCRIPTION
Problem:
Including this library in another library can cause double declaration compile errors, due to the whacky Arduino build process.

Solution:
This change adds include guards to the header file. This prevents the header from being included more than once.

More about include guards: http://stackoverflow.com/questions/1653958/why-are-ifndef-and-define-used-in-c-header-files
