### PR TITLE
Change return type of method connectToAP to bool

### DIFF
--- a/Adafruit_CC3000.h
+++ b/Adafruit_CC3000.h
@@ -104,7 +104,7 @@ class Adafruit_CC3000 {
     bool     getMacAddress(uint8_t address[6]);
     bool     setMacAddress(uint8_t address[6]);
 
-    void     connectToAP(const char *ssid, const char *key, uint8_t secmode);
+    bool     connectToAP(const char *ssid, const char *key, uint8_t secmode);
     bool     connectSecure(const char *ssid, const char *key, int32_t secMode);
     bool     connectOpen(const char *ssid); 
     bool     checkConnected(void);

--- a/examples/GeoLocation/GeoLocation.ino
+++ b/examples/GeoLocation/GeoLocation.ino
@@ -93,7 +93,10 @@ void setup(void) {
   }
 
   Serial.print(F("OK.\r\nConnecting to network..."));
-  cc3000.connectToAP(WLAN_SSID, WLAN_PASS, WLAN_SECURITY);
+  if(!cc3000.connectToAP(WLAN_SSID, WLAN_PASS, WLAN_SECURITY)) {
+    Serial.println(F("Failed!"));
+    return;
+  }
   Serial.println(F("connected!"));
 
   Serial.print(F("Requesting address from DHCP server..."));

--- a/examples/InternetTime/InternetTime.ino
+++ b/examples/InternetTime/InternetTime.ino
@@ -86,7 +86,10 @@ void setup(void)
   Serial.print(F("\nAttempting to connect to ")); Serial.println(ssid);
   
   /* NOTE: Secure connections are not available in 'Tiny' mode! */
-  cc3000.connectToAP(WLAN_SSID, WLAN_PASS, WLAN_SECURITY);
+  if (!cc3000.connectToAP(WLAN_SSID, WLAN_PASS, WLAN_SECURITY)) {
+    Serial.println(F("Failed!"));
+    while(1);
+  }
    
   Serial.println(F("Connected!"));
   

--- a/examples/SendTweet/SendTweet.ino
+++ b/examples/SendTweet/SendTweet.ino
@@ -141,7 +141,7 @@ void setup(void) {
 
   Serial.print(F("OK\r\nConnecting to network..."));
   /* NOTE: Secure connections are not available in 'Tiny' mode! */
-  cc3000.connectToAP(WLAN_SSID, WLAN_PASS, WLAN_SECURITY);
+  if(!cc3000.connectToAP(WLAN_SSID, WLAN_PASS, WLAN_SECURITY)) hang(F("Failed!"));
 
   Serial.print(F("OK\r\nRequesting address from DHCP server..."));
   for(t=millis(); !cc3000.checkDHCP() && ((millis() - t) < dhcpTimeout); delay(100));

--- a/examples/WebClient/WebClient.ino
+++ b/examples/WebClient/WebClient.ino
@@ -78,7 +78,10 @@ void setup(void)
   // Optional SSID scan
   // listSSIDResults();
   
-  cc3000.connectToAP(WLAN_SSID, WLAN_PASS, WLAN_SECURITY);
+  if (!cc3000.connectToAP(WLAN_SSID, WLAN_PASS, WLAN_SECURITY)) {
+    Serial.println(F("Failed!"));
+    while(1);
+  }
    
   Serial.println(F("Connected!"));
   

--- a/examples/buildtest/buildtest.ino
+++ b/examples/buildtest/buildtest.ino
@@ -107,7 +107,10 @@ void setup(void)
   Serial.print(F("\nAttempting to connect to ")); Serial.println(ssid);
   
   /* NOTE: Secure connections are not available in 'Tiny' mode! */
-  cc3000.connectToAP(WLAN_SSID, WLAN_PASS, WLAN_SECURITY);
+  if (!cc3000.connectToAP(WLAN_SSID, WLAN_PASS, WLAN_SECURITY)) {
+    Serial.println(F("Failed!"));
+    while(1);
+  }
    
   Serial.println(F("Connected!"));
   

--- a/examples/ntpTest/ntpTest.ino
+++ b/examples/ntpTest/ntpTest.ino
@@ -153,7 +153,10 @@ void setup(void)
   Serial.print(F("\nAttempting to connect to ")); Serial.println(ssid);
   
   /* NOTE: Secure connections are not available in 'Tiny' mode! */
-  cc3000.connectToAP(WLAN_SSID, WLAN_PASS, WLAN_SECURITY);
+  if (!cc3000.connectToAP(WLAN_SSID, WLAN_PASS, WLAN_SECURITY)) {
+    Serial.println(F("Failed!"));
+    while(1);
+  }
    
   Serial.println(F("Connected!"));
   


### PR DESCRIPTION
Similar to the methods connectSecure and connectOpen, a boolean value indicating success or failure is returned by connectToAP.

Furthermore some additional checks have been added to methods getIPAddress, ping, and getHostByName; they require the device to be connected and the DHCP process to be completed.

Method begin can return immediately if the device is already initialised.
