### PR TITLE
Change signature of method startSSIDscan

### DIFF
--- a/Adafruit_CC3000.cpp
+++ b/Adafruit_CC3000.cpp
@@ -611,9 +611,7 @@ status_t Adafruit_CC3000::getStatus()
 ResultStruct_t SSIDScanResultBuff;
 
 
-uint16_t Adafruit_CC3000::startSSIDscan() {
-  uint16_t   index = 0;
-
+bool Adafruit_CC3000::startSSIDscan(uint32_t *index) {
   if (!_initialised)
   {
     return false;
@@ -632,8 +630,8 @@ uint16_t Adafruit_CC3000::startSSIDscan() {
   CHECK_SUCCESS(wlan_ioctl_get_scan_results(0, (uint8_t* ) &SSIDScanResultBuff),
                 "SSID scan failed!", false);
 
-  index = SSIDScanResultBuff.num_networks;
-  return index;
+  *index = SSIDScanResultBuff.num_networks;
+  return true;
 }
 
 void Adafruit_CC3000::stopSSIDscan(void) {

--- a/Adafruit_CC3000.h
+++ b/Adafruit_CC3000.h
@@ -119,7 +119,7 @@ class Adafruit_CC3000 {
     #ifndef CC3000_TINY_DRIVER
     bool     getFirmwareVersion(uint8_t *major, uint8_t *minor);
     status_t getStatus(void);
-    uint16_t startSSIDscan(void);
+    bool     startSSIDscan(uint32_t *index);
     void     stopSSIDscan();
     uint8_t  getNextSSID(uint8_t *rssi, uint8_t *secMode, char *ssidname);
 

--- a/examples/WebClient/WebClient.ino
+++ b/examples/WebClient/WebClient.ino
@@ -159,10 +159,14 @@ void loop(void)
 
 void listSSIDResults(void)
 {
-  uint8_t valid, rssi, sec, index;
+  uint32_t index;
+  uint8_t valid, rssi, sec;
   char ssidname[33]; 
 
-  index = cc3000.startSSIDscan();
+  if (!cc3000.startSSIDscan(&index)) {
+    Serial.println(F("SSID scan failed!"));
+    return;
+  }
 
   Serial.print(F("Networks found: ")); Serial.println(index);
   Serial.println(F("================================================"));

--- a/examples/buildtest/buildtest.ino
+++ b/examples/buildtest/buildtest.ino
@@ -255,10 +255,14 @@ bool displayConnectionDetails(void)
 
 void listSSIDResults(void)
 {
-  uint8_t valid, rssi, sec, index;
+  uint32_t index;
+  uint8_t valid, rssi, sec;
   char ssidname[33]; 
 
-  index = cc3000.startSSIDscan();
+  if (!cc3000.startSSIDscan(&index)) {
+    Serial.println(F("SSID scan failed!"));
+    return;
+  }
 
   Serial.print(F("Networks found: ")); Serial.println(index);
   Serial.println(F("================================================"));


### PR DESCRIPTION
The return value of method startSSIDscan has been used for two purposes; the number of networks (when executed successfully) and status reporting (return false). To better distinguish between (real) results and status information, the method's return type has been changed to bool. The original return value (number of networks) is now a reference parameter.

The type of the reference parameter has been changed to uint32_t according to field num_networks of ResultStruct_t.
