### PR TITLE
Use separate timeout for each AP connection attempt.

### DIFF
--- a/Adafruit_CC3000.cpp
+++ b/Adafruit_CC3000.cpp
@@ -951,7 +951,7 @@ bool Adafruit_CC3000::connectToAP(const char *ssid, const char *key, uint8_t sec
     return false;
   }
 
-  int16_t timer = WLAN_CONNECT_TIMEOUT;
+  int16_t timer;
 
   do {
     cc3k_int_poll();
@@ -985,6 +985,8 @@ bool Adafruit_CC3000::connectToAP(const char *ssid, const char *key, uint8_t sec
       }
 #endif
     }
+	  
+    timer = WLAN_CONNECT_TIMEOUT;
 
     /* Wait around a bit for the async connected signal to arrive or timeout */
     if (CC3KPrinter != 0) CC3KPrinter->print(F("Waiting to connect..."));


### PR DESCRIPTION
With this pull request, the timeout in connectToAP() is reset for each connection attempt, allowing subsequent connections to succeed even if a previous one timed out. Without this change, if the connection attempt times out once, subsequent attempts timeout immediately, since timer is already at 0. That makes it almost impossible to connect after an initial timeout.
