### PR TITLE
Remove tx buffer from client, add tests, and fix bugs with fastrprint handling null strings.

### DIFF
--- a/Adafruit_CC3000.h
+++ b/Adafruit_CC3000.h
@@ -80,7 +80,6 @@ class Adafruit_CC3000_Client : public Print {
   uint8_t available(void);
 
   uint8_t _rx_buf[RXBUFFERSIZE], _rx_buf_idx;
-  char    _tx_buf[TXBUFFERSIZE];
   int16_t bufsiz;
 
  private:

--- a/tests/Client_fastrprint/Client_fastrprint.ino
+++ b/tests/Client_fastrprint/Client_fastrprint.ino
@@ -1,0 +1,199 @@
+/*************************************************** 
+  Client_fastrprint test
+
+  Designed specifically to work with the Adafruit WiFi products:
+  ----> https://www.adafruit.com/products/1469
+
+  Adafruit invests time and resources providing this open source code, 
+  please support Adafruit and open-source hardware by purchasing 
+  products from Adafruit!
+
+  Written by Tony DiCola, based on code example code written by
+  Limor Fried & Kevin Townsend for Adafruit Industries.  
+  BSD license, all text above must be included in any redistribution
+ ****************************************************/
+ 
+#include <Adafruit_CC3000.h>
+#include <ccspi.h>
+#include <SPI.h>
+#include <string.h>
+#include "utility/debug.h"
+
+// These are the interrupt and control pins
+#define ADAFRUIT_CC3000_IRQ   3  // MUST be an interrupt pin!
+// These can be any two pins
+#define ADAFRUIT_CC3000_VBAT  5
+#define ADAFRUIT_CC3000_CS    10
+// Use hardware SPI for the remaining pins
+// On an UNO, SCK = 13, MISO = 12, and MOSI = 11
+Adafruit_CC3000 cc3000 = Adafruit_CC3000(ADAFRUIT_CC3000_CS, ADAFRUIT_CC3000_IRQ, ADAFRUIT_CC3000_VBAT,
+                                         SPI_CLOCK_DIV2); // you can change this clock speed
+
+#define WLAN_SSID       "myNetwork"           // cannot be longer than 32 characters!
+#define WLAN_PASS       "myPassword"
+
+// Security can be WLAN_SEC_UNSEC, WLAN_SEC_WEP, WLAN_SEC_WPA or WLAN_SEC_WPA2
+#define WLAN_SECURITY   WLAN_SEC_WPA2
+
+// Test server configuration
+const uint8_t   SERVER_IP[4]   = { 192, 168, 1, 101 };
+const uint16_t  SERVER_PORT    = 9000;
+
+#define ASSERT_EQ(expected, actual) { \
+  if (actual != expected) { \
+    Serial.print("FAILURE: Expected "); \
+    Serial.print(actual); \
+    Serial.print(" to equal "); \
+    Serial.println(expected); \
+  } \
+}
+
+#define TEST_FASTRPRINT(message, client) { \
+  Serial.print("Testing fastrprint with char* input: "); \
+  Serial.println(message); \
+  unsigned long n = client.fastrprint(message); \
+  ASSERT_EQ(sizeof(message)-1, n); \
+}
+
+#define TEST_FASTRPRINTLN(message, client) { \
+  Serial.print("Testing fastrprintln with char* input: "); \
+  Serial.println(message); \
+  unsigned long n = client.fastrprintln(message); \
+  ASSERT_EQ(sizeof(message)+1, n); \
+}
+
+#define TEST_FASTRPRINT_F(message, client) { \
+  Serial.print("Testing fastrprint with flash string input: "); \
+  Serial.println(F(message)); \
+  unsigned long n = client.fastrprint(F(message)); \
+  ASSERT_EQ(sizeof(message)-1, n); \
+}
+
+#define TEST_FASTRPRINTLN_F(message, client) { \
+  Serial.print("Testing fastrprintln with flash string input: "); \
+  Serial.println(F(message)); \
+  unsigned long n = client.fastrprintln(F(message)); \
+  ASSERT_EQ(sizeof(message)+1, n); \
+}
+
+// Run the test
+void runTest(void) {
+  // Make two connections to the server running listener.py
+  Serial.println(F("Connecting to server..."));
+  Adafruit_CC3000_Client client1 = cc3000.connectTCP(cc3000.IP2U32(SERVER_IP[0], SERVER_IP[1], SERVER_IP[2], SERVER_IP[3]), 
+                                                     SERVER_PORT);
+  if (!client1.connected()) {
+    Serial.println(F("Couldn't connect to server! Make sure listener.py is running on the server."));
+    while(1);
+  }
+  Adafruit_CC3000_Client client2 = cc3000.connectTCP(cc3000.IP2U32(SERVER_IP[0], SERVER_IP[1], SERVER_IP[2], SERVER_IP[3]), 
+                                                     SERVER_PORT);
+  if (!client2.connected()) {
+    Serial.println(F("Couldn't connect to server! Make sure listener.py is running on the server."));
+    while(1);
+  }
+  Serial.println(F("Connected!"));
+  
+  // Start the test
+  Serial.print(F("Free RAM: ")); Serial.println(getFreeRam(), DEC);
+  Serial.println(F("Starting tests..."));
+  unsigned long start = millis();
+  
+  // Test character strings
+  TEST_FASTRPRINT("Fastrprint string.", client1);
+  TEST_FASTRPRINT("Fastrprint with a large (>32 character) character string!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", client1);
+  TEST_FASTRPRINTLN("Fastrprintln string.", client1);
+  TEST_FASTRPRINTLN("Fastrprintln with a large (>32 character) character string!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", client1);
+  
+  // Test flash strings
+  TEST_FASTRPRINT_F("Fastrprint flash.", client1);
+  TEST_FASTRPRINT_F("Fastrprint with a large (>32 character) flash string!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", client1);
+  TEST_FASTRPRINTLN_F("Fastrprintln flash.", client1);
+  TEST_FASTRPRINTLN_F("Fastrprintln with a large (>32 character) flash string!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", client1);
+  
+  // Test empty strings
+  TEST_FASTRPRINT("", client1);
+  TEST_FASTRPRINTLN("", client1);
+  TEST_FASTRPRINT_F("", client1);
+  TEST_FASTRPRINTLN_F("", client1);
+  
+  // Test printing to multiple clients
+  TEST_FASTRPRINT("This is a message for client 1.", client1);
+  TEST_FASTRPRINT("This is a message for client 2.", client2);
+  TEST_FASTRPRINT_F("This is a flash message for client 1.", client1);
+  TEST_FASTRPRINT_F("This is a flash message for client 2.", client2);
+  TEST_FASTRPRINT_F("This is a large (>32 character) flash message for client 1!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", client1);
+  TEST_FASTRPRINT_F("This is a large (>32 character) flash message for client 2!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", client2);
+
+  unsigned long finish = millis();
+  Serial.println(F("Tests finished!"));
+  Serial.print(F("Free RAM: ")); Serial.println(getFreeRam(), DEC);
+  Serial.print(F("Time taken to run test (MS): ")); Serial.println(finish - start, DEC);
+  
+  client1.close();
+  client2.close();
+  cc3000.disconnect();
+}
+
+// Set up the HW and the CC3000 module (called automatically on startup)
+void setup(void)
+{
+  Serial.begin(115200);
+  Serial.println(F("Hello, CC3000!\n")); 
+  
+  /* Initialise the module */
+  Serial.println(F("\nInitializing..."));
+  if (!cc3000.begin())
+  {
+    Serial.println(F("Couldn't begin()! Check your wiring?"));
+    while(1);
+  }
+  
+  if (!cc3000.connectToAP(WLAN_SSID, WLAN_PASS, WLAN_SECURITY)) {
+    Serial.println(F("Failed!"));
+    while(1);
+  }
+   
+  Serial.println(F("Connected!"));
+  
+  /* Wait for DHCP to complete */
+  Serial.println(F("Request DHCP"));
+  while (!cc3000.checkDHCP())
+  {
+    delay(100); // ToDo: Insert a DHCP timeout!
+  }  
+
+  /* Display the IP address DNS, Gateway, etc. */  
+  while (! displayConnectionDetails()) {
+    delay(1000);
+  }
+  
+  runTest();
+}
+
+void loop(void)
+{
+ delay(1000);
+}
+
+// Tries to read the IP address and other connection details
+bool displayConnectionDetails(void)
+{
+  uint32_t ipAddress, netmask, gateway, dhcpserv, dnsserv;
+  
+  if(!cc3000.getIPAddress(&ipAddress, &netmask, &gateway, &dhcpserv, &dnsserv))
+  {
+    Serial.println(F("Unable to retrieve the IP Address!\r\n"));
+    return false;
+  }
+  else
+  {
+    Serial.print(F("\nIP Addr: ")); cc3000.printIPdotsRev(ipAddress);
+    Serial.print(F("\nNetmask: ")); cc3000.printIPdotsRev(netmask);
+    Serial.print(F("\nGateway: ")); cc3000.printIPdotsRev(gateway);
+    Serial.print(F("\nDHCPsrv: ")); cc3000.printIPdotsRev(dhcpserv);
+    Serial.print(F("\nDNSserv: ")); cc3000.printIPdotsRev(dnsserv);
+    Serial.println();
+    return true;
+  }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,27 @@
+Adafruit CC3000 Library Tests
+=============================
+
+This folder is meant to contain tests that are written to verify the CC3000 library.  Consumers
+of the library probably want to ignore the contents of this folder.
+
+Files:
+------
+
+-	listener.py
+	
+	Python script to run a TCP socket server which listens by default on port 9000 (but can be
+	changed by specifying a different port in the first command line parameter), accepts any
+	connections and echos all received data to standard output.  This is required for running some
+	of the tests.  In general you'll want to run listener.py with stdout directed to a file and then
+	run the test sketch on the CC3000 to capture what is output.  Compare the output of test runs
+	before and after making a change/bugfix to the library and diff the results to ensure no
+	unexpected changes in functionality.
+
+Tests:
+------
+
+-	Client\_fastrprint
+
+	Manual test to verify the fastrprint and fastrprintln functions of the client library.  Must
+	update the sketch to connect to your wireless network and set the SERVER_IP value to the IP
+	of a server running listener.py.

--- a/tests/listener.py
+++ b/tests/listener.py
@@ -1,0 +1,45 @@
+# Adafruit CC3000 Library Test Listener
+# Created by Tony DiCola (tony@tonydicola.com)
+# Released with the same license as the Adafruit CC3000 library (BSD)
+
+# Create a simple server to listen by default on port 9000 (or on the port specified in
+# the first command line parameter), accept any connections and print all data received
+# to standard output.  Must be terminated by hitting ctrl-c to kill the process!
+
+from socket import *
+import sys
+import threading
+
+SERVER_PORT = 9000
+if len(sys.argv) > 1:
+	SERVER_PORT = sys.argv[1]
+
+# Create listening socket
+server = socket(AF_INET, SOCK_STREAM)
+
+# Ignore waiting for the socket to close if it's already open.  See the python socket
+# doc for more info (very bottom of http://docs.python.org/2/library/socket.html).
+server.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
+
+# Listen on any network interface for the specified port
+server.bind(('', SERVER_PORT))
+server.listen(5)
+
+# Worker process to print all data received to standard output.
+def process_connection(client):
+	while True:
+		data = client.recv(1024)
+		sys.stdout.write(data) # Don't use print because it appends spaces and newlines
+		sys.stdout.flush()
+		if not data: 
+			break
+	client.close()
+
+try:
+	# Wait for connections and spawn worker threads to process them.
+	while True:
+		client, address = server.accept()
+		thread = threading.Thread(target=process_connection, args=(client,))
+		thread.start()
+except:
+	server.close()


### PR DESCRIPTION
This commit does the following:
- Removes the transmit buffer from being a member of each client instance.  The transmit buffer is only used
  to buffer strings from flash memory to send out on sockets, therefore it's not necessary to have a separate
  buffer with each client.  The transmist buffer is now a local variable of the fastrprint function.
- Adds a test directory with a small suite of tests for the fastrprint function.  A README.md explains the
  usage of the tests, and a small python script is provided for capturing output of tests.
- Fixes a few bugs with fastrprint and fastrprintln calling send (and sending garbage data on the socket) when
  they receive a null string.  Simple string length checks now catch these conditions and respond appropriately.
- Puts an end of line constant used by fastrprintln into flash memory instead of RAM.

This commit was tested by running the included Client_fastrprint test suite before and after the changes,
capturing the output of these tests, and comparing the before/after output with diff to ensure there was no
change in functionality.  Execution time of the tests before and after was mostly unchanged, 134 vs. 135
milliseconds.  Memory usage with multiple clients decreased as expected by moving the tx buffer out of each
class instance.
