### PR TITLE
Add support for ATmega1284P processor

### DIFF
--- a/Adafruit_CC3000.cpp
+++ b/Adafruit_CC3000.cpp
@@ -47,6 +47,12 @@ static const uint8_t dreqinttable[] = {
   20, 3,
   19, 4,
   18, 5,
+// Support for the ATmega1284P processor based on the popular 'Mighty 1284P' board pinout documented here: 
+// https://github.com/maniacbug/mighty-1284p/
+#elif defined(__AVR_ATmega1284P__)
+  10, 0,
+  11, 1,
+  2, 2,
 #elif  defined(__AVR_ATmega32U4__) && defined(CORE_TEENSY)
   5, 0,
   6, 1,


### PR DESCRIPTION
This small change adds support for the ATmega1284P processor using the popular 'Mighty 1284P' pinout (as documented at http://maniacbug.wordpress.com/2011/11/27/arduino-on-atmega1284p-4/ and https://github.com/maniacbug/mighty-1284p/).  Unfortunately there is no official Arduino pinout for the ATmega1284P processor, however the 'Mighty 1284P' bootloader and pinout is the most well documented, and follows the conventions of official Arduinos.

This change was tested using an ATmega1284P setup as a breadboard Arduino running the mighty 1284p bootloader.  The buildtest, chat server, and web client examples were run to verify functionality.

This pin to interrupt mapping should also work for other processors like the ATmega1284, ATmega644A/PA, etc. but has not been tested with them so they weren't added.
