### PR TITLE
ignore null pointers in accept (don't write to them)

### DIFF
--- a/utility/socket.cpp
+++ b/utility/socket.cpp
@@ -329,8 +329,8 @@ accept(long sd, sockaddr *addr, socklen_t *addrlen)
 	
 	
 	// need specify return parameters!!!
-	memcpy(addr, &tAcceptReturnArguments.tSocketAddress, ASIC_ADDR_LEN);
-	*addrlen = ASIC_ADDR_LEN;
+	if (addr) memcpy(addr, &tAcceptReturnArguments.tSocketAddress, ASIC_ADDR_LEN);
+	if (addrlen) *addrlen = ASIC_ADDR_LEN;
 	errno = tAcceptReturnArguments.iStatus; 
 	ret = errno;
 	


### PR DESCRIPTION
Adafruit_CC3000_Server.cpp calls accept() with NULL pointers, because it's not interested in the IP number.  This tiny patch prevents accept() from writing to those pointers if they're NULL.

On ARM (Teensy 3.0), writing to a NULL pointer causes a memory fault that stops the program.  On AVR, it silently overwrites the register bank, which certainly is not good.

Discussion here:
http://forums.adafruit.com/viewtopic.php?f=22&t=46726&p=235230#p235230
