### PR TITLE
Add optional CC3K debug printer to main class constructor.

### DIFF
--- a/Adafruit_CC3000.cpp
+++ b/Adafruit_CC3000.cpp
@@ -181,10 +181,13 @@ bool Adafruit_CC3000::scanSSIDs(uint32_t time)
 
 /**************************************************************************/
 /*!
-    @brief  Instantiates a new CC3000 class
+    @brief  Instantiates a new CC3000 class.
+            Note that by default this class will assume the first hardware 
+            serial should be used for debug output.  This behavior can be
+            changed by explicitly specifying a cc3kPrinter parameter.
 */
 /**************************************************************************/
-Adafruit_CC3000::Adafruit_CC3000(uint8_t csPin, uint8_t irqPin, uint8_t vbatPin, uint8_t SPIspeed)
+Adafruit_CC3000::Adafruit_CC3000(uint8_t csPin, uint8_t irqPin, uint8_t vbatPin, uint8_t SPIspeed, Print* cc3kPrinter)
 {
   _initialised = false;
   g_csPin = csPin;
@@ -198,12 +201,7 @@ Adafruit_CC3000::Adafruit_CC3000(uint8_t csPin, uint8_t irqPin, uint8_t vbatPin,
   ulSocket              = 0;
   ulSmartConfigFinished = 0;
 
-  #if defined(UDR0) || defined(UDR1) || defined(CORE_TEENSY) || ( defined (__arm__) && defined (__SAM3X8E__) )
-  CC3KPrinter = &Serial;
-  #else
-  CC3KPrinter = 0;
-  // no default serial port found
-  #endif
+  CC3KPrinter = cc3kPrinter;
 }
 
 /* *********************************************************************** */

--- a/Adafruit_CC3000.h
+++ b/Adafruit_CC3000.h
@@ -36,6 +36,12 @@
   #define SPI_CLOCK_DIVIDER SPI_CLOCK_DIV128
 #endif
 
+#if defined(UDR0) || defined(UDR1) || defined(CORE_TEENSY) || ( defined (__arm__) && defined (__SAM3X8E__) )
+  #define CC3K_DEFAULT_PRINTER &Serial
+#else
+  #define CC3K_DEFAULT_PRINTER 0
+#endif
+
 #define WLAN_CONNECT_TIMEOUT 10000  // how long to wait, in milliseconds
 #define RXBUFFERSIZE  64 // how much to buffer on the incoming side
 #define TXBUFFERSIZE  32 // how much to buffer on the outgoing side
@@ -106,7 +112,7 @@ class Adafruit_CC3000_Client : public Print {
 
 class Adafruit_CC3000 {
   public:
-  Adafruit_CC3000(uint8_t csPin, uint8_t irqPin, uint8_t vbatPin, uint8_t spispeed = SPI_CLOCK_DIVIDER);
+    Adafruit_CC3000(uint8_t csPin, uint8_t irqPin, uint8_t vbatPin, uint8_t spispeed = SPI_CLOCK_DIVIDER, Print* cc3kPrinter = CC3K_DEFAULT_PRINTER);
     bool     begin(uint8_t patchReq = 0, bool useSmartConfigData = false);
     void     reboot(uint8_t patchReq = 0);
     void     stop(void);


### PR DESCRIPTION
This optional parameter allows a user to specify their own Print object for receiving debug output.  The default behavior of choosing hardware serial 1 is unchanged if the parameter is not specified.  This change follows the conventions of Arduino libraries and allows a user to use the hardware serial port without running into problems with the CC3K attempting to use it too.

This change was tested by running all the examples from the CC3000 test suite (here https://github.com/ladyada/CC3000_testing ) and verifying there were no regressions.  I also ran a version of the buildtest example which specified a null value for the printer and verified no debug output was written.
