### PR TITLE
Add connecting message to examples which will need it after integrating debug logging change.

### DIFF
--- a/examples/ChatServer/ChatServer.ino
+++ b/examples/ChatServer/ChatServer.ino
@@ -104,6 +104,7 @@ void setup(void)
     while(1);
   }
   
+  Serial.print(F("\nAttempting to connect to ")); Serial.println(WLAN_SSID);
   if (!cc3000.connectToAP(WLAN_SSID, WLAN_PASS, WLAN_SECURITY)) {
     Serial.println(F("Failed!"));
     while(1);

--- a/examples/EchoServer/EchoServer.ino
+++ b/examples/EchoServer/EchoServer.ino
@@ -110,6 +110,7 @@ void setup(void)
     while(1);
   }
   
+  Serial.print(F("\nAttempting to connect to ")); Serial.println(WLAN_SSID);
   if (!cc3000.connectToAP(WLAN_SSID, WLAN_PASS, WLAN_SECURITY)) {
     Serial.println(F("Failed!"));
     while(1);

--- a/examples/WebClient/WebClient.ino
+++ b/examples/WebClient/WebClient.ino
@@ -82,6 +82,7 @@ void setup(void)
   // Optional SSID scan
   // listSSIDResults();
   
+  Serial.print(F("\nAttempting to connect to ")); Serial.println(WLAN_SSID);
   if (!cc3000.connectToAP(WLAN_SSID, WLAN_PASS, WLAN_SECURITY)) {
     Serial.println(F("Failed!"));
     while(1);


### PR DESCRIPTION
Adding explicit connecting messages to the WebClient, ChatServer, and EchoServer examples.  This is necessary after taking this pull request which removed some of the logging (to save flash space): https://github.com/adafruit/Adafruit_CC3000_Library/pull/64
