### PR TITLE
Update Adafruit_CC3000.cpp

### DIFF
--- a/Adafruit_CC3000.cpp
+++ b/Adafruit_CC3000.cpp
@@ -164,8 +164,9 @@ bool Adafruit_CC3000::scanSSIDs(uint32_t time)
     }
   }
 
+  // Set  SSID Scan params to includes channels above 11 
   CHECK_SUCCESS(
-      wlan_ioctl_set_scan_params(time, 20, 100, 5, 0x7FF, -120, 0, 300,
+      wlan_ioctl_set_scan_params(time, 20, 100, 5, 0x1FFF, -120, 0, 300,
           (unsigned long * ) &intervalTime),
           "Failed setting params for SSID scan", false);
 


### PR DESCRIPTION
Update call to  wlan_ioctl_set_scan_params to enable channels above 11 to be scanned. Here in the UK it's common to have wifi set up to use channels above 11. 
