### PR TITLE
Patch for Smart Config 

### DIFF
--- a/Adafruit_CC3000.cpp
+++ b/Adafruit_CC3000.cpp
@@ -141,13 +141,7 @@ private:
 }cc3000Bitset;
 
 volatile long ulSocket;
-
-char _deviceName[] = "CC3000";
 char _cc3000_prefix[] = { 'T', 'T', 'T' };
-const unsigned char _smartConfigKey[] = { 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
-                                          0x38, 0x39, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35 };
-                                          // AES key for smart config = "0123456789012345"
-
 Print* CC3KPrinter; // user specified output stream for general messages and debug
 
 /* *********************************************************************** */
@@ -245,7 +239,7 @@ Adafruit_CC3000::Adafruit_CC3000(uint8_t csPin, uint8_t irqPin, uint8_t vbatPin,
               clean connection
 */
 /**************************************************************************/
-bool Adafruit_CC3000::begin(uint8_t patchReq, bool useSmartConfigData)
+bool Adafruit_CC3000::begin(uint8_t patchReq, bool useSmartConfigData, const char *_deviceName)
 {
   if (_initialised) return true;
 
@@ -312,7 +306,7 @@ bool Adafruit_CC3000::begin(uint8_t patchReq, bool useSmartConfigData)
 
   _initialised = true;
 
-  // Wait for re-connection is we're using SmartConfig data
+  // Wait for re-connection if we're using SmartConfig data
   if (useSmartConfigData)
   {
     // Wait for a connection
@@ -754,8 +748,9 @@ uint8_t Adafruit_CC3000::getNextSSID(uint8_t *rssi, uint8_t *secMode, char *ssid
 */
 /**************************************************************************/
 #ifndef CC3000_TINY_DRIVER
-bool Adafruit_CC3000::startSmartConfig(bool enableAES)
+bool Adafruit_CC3000::startSmartConfig(const char *_deviceName, const char *smartConfigKey)
 {
+  bool enableAES = smartConfigKey != NULL;
   cc3000Bitset.clear();
 
   uint32_t   timeout = 0;
@@ -791,10 +786,12 @@ bool Adafruit_CC3000::startSmartConfig(bool enableAES)
   CHECK_SUCCESS(nvmem_create_entry(NVMEM_AES128_KEY_FILEID,16),
                 "Failed create NVMEM entry", false);
   
-  // write AES key to NVMEM
-  CHECK_SUCCESS(aes_write_key((unsigned char *)(&_smartConfigKey[0])),
-                "Failed writing AES key", false);  
-  
+  if (enableAES)
+  {
+    // write AES key to NVMEM
+    CHECK_SUCCESS(aes_write_key((unsigned char *)(smartConfigKey)),
+                  "Failed writing AES key", false);  
+  }  
   //CC3KPrinter->println("Set prefix");
   // Wait until CC3000 is disconnected
   CHECK_SUCCESS(wlan_smart_config_set_prefix((char *)&_cc3000_prefix),

--- a/Adafruit_CC3000.h
+++ b/Adafruit_CC3000.h
@@ -116,7 +116,7 @@ class Adafruit_CC3000_Client : public Print {
 class Adafruit_CC3000 {
   public:
   Adafruit_CC3000(uint8_t csPin, uint8_t irqPin, uint8_t vbatPin, uint8_t spispeed = SPI_CLOCK_DIVIDER);
-    bool     begin(uint8_t patchReq = 0, bool useSmartConfigData = false);
+    bool     begin(uint8_t patchReq = 0, bool useSmartConfigData = false, const char *_deviceName = NULL);
     void     reboot(uint8_t patchReq = 0);
     void     stop(void);
     bool     disconnect(void);
@@ -149,7 +149,7 @@ class Adafruit_CC3000 {
     uint8_t  getNextSSID(uint8_t *rssi, uint8_t *secMode, char *ssidname);
 
     bool     listSSIDResults(void);
-    bool     startSmartConfig(bool enableAES);
+    bool     startSmartConfig(const char *_deviceName = NULL, const char *smartConfigKey = NULL);
 
     bool     getIPConfig(tNetappIpconfigRetArgs *ipConfig);
 

--- a/utility/socket.cpp
+++ b/utility/socket.cpp
@@ -1,3 +1,5 @@
+#define SEND_TIMEOUT_MS (30 * 1000)
+
 /*****************************************************************************
 *
 *  socket.c  - CC3000 Host Driver Implementation.
@@ -123,6 +125,11 @@ HostFlowControlConsumeBuff(int sd)
 {
 #ifndef SEND_NON_BLOCKING
 	/* wait in busy loop */
+
+#ifdef SEND_TIMEOUT_MS
+	unsigned long startTime = millis();
+#endif
+
 	do
 	{
 		// In case last transmission failed then we will return the last failure 
@@ -137,6 +144,14 @@ HostFlowControlConsumeBuff(int sd)
 		
 		if(SOCKET_STATUS_ACTIVE != get_socket_active_status(sd))
 			return -1;
+
+#ifdef SEND_TIMEOUT_MS
+		if ((millis() - startTime) > SEND_TIMEOUT_MS)
+		{
+			return -3; /* Timeout */
+		}
+#endif
+
 	} while(0 == tSLInformation.usNumberOfFreeBuffers);
 	
 	tSLInformation.usNumberOfFreeBuffers--;


### PR DESCRIPTION
This is a small patch to make Smart Config a little more flexible. deviceName and smartConfigKey are now passed in as parameters to startSmartConfig(), and a timeout has been added in HostFlowControlConsumeBuff to detect issues with CC3000 deadlocks.
