### PR TITLE
Feature/inherit client

### DIFF
--- a/Adafruit_CC3000.cpp
+++ b/Adafruit_CC3000.cpp
@@ -1239,7 +1239,7 @@ Adafruit_CC3000_Client Adafruit_CC3000::connectTCP(uint32_t destIP, uint16_t des
 
   //printHex((byte *)&socketAddress, sizeof(socketAddress));
   //if (CC3KPrinter != 0) CC3KPrinter->print(F("Connecting socket ... "));
-  if (-1 == connectX(tcp_socket, &socketAddress, sizeof(socketAddress)))
+  if (-1 == ::connect(tcp_socket, &socketAddress, sizeof(socketAddress)))
   {
     CHECK_PRINTER {
 		CC3KPrinter->println(F("Connection error"));
@@ -1289,7 +1289,7 @@ Adafruit_CC3000_Client Adafruit_CC3000::connectUDP(uint32_t destIP, uint16_t des
   }
 
   //printHex((byte *)&socketAddress, sizeof(socketAddress));
-  if (-1 == connectX(udp_socket, &socketAddress, sizeof(socketAddress)))
+  if (-1 == ::connect(udp_socket, &socketAddress, sizeof(socketAddress)))
   {
     CHECK_PRINTER {
 		CC3KPrinter->println(F("Connection error"));
@@ -1388,7 +1388,7 @@ int Adafruit_CC3000_Client::connect(IPAddress destIP, uint16_t destPort)
 
   //printHex((byte *)&socketAddress, sizeof(socketAddress));
   //if (CC3KPrinter != 0) CC3KPrinter->print(F("Connecting socket ... "));
-  if (-1 == connectX(tcp_socket, &socketAddress, sizeof(socketAddress)))
+  if (-1 == ::connect(tcp_socket, &socketAddress, sizeof(socketAddress)))
   {
     CHECK_PRINTER {
       CC3KPrinter->println(F("Connection error"));

--- a/utility/socket.cpp
+++ b/utility/socket.cpp
@@ -535,7 +535,7 @@ gethostbyname(const char * hostname, uint8_t usNameLen, uint32_t * out_ip_addr)
 //*****************************************************************************
 
 long
-connectX(long sd, const sockaddr *addr, long addrlen)
+connect(long sd, const sockaddr *addr, long addrlen)
 {
 	long int ret;
 	unsigned char *ptr, *args;

--- a/utility/socket.h
+++ b/utility/socket.h
@@ -405,7 +405,7 @@ extern int gethostbyname(const char * hostname, uint8_t usNameLen, uint32_t* out
 //!  @sa socket
 //
 //*****************************************************************************
-extern long connectX(long sd, const sockaddr *addr, long addrlen);
+extern long connect(long sd, const sockaddr *addr, long addrlen);
 
 //*****************************************************************************
 //


### PR DESCRIPTION
Implement Arduinos Client so you can utilize existing Ethernet, etc code. Resolves #70 and many forum threads.

Mainly just conformed to return values of virtualized functions and added a connect function from client. Now in addition to getting a connected client back from cc300, you can tcp connect your unconnected client object like so:

``` cpp
Adafruit_CC3000_Client www = Adafruit_CC3000_Client();
www.connect(ip,port);
```

And also have working peek now as well. Flush is a placeholder as I'm not sure its possible or necessary?

One thing needs to be changed before acceptance. I dont understand why currently, but connect from socket.h was conflicting was connect from Client.h.  I renamed socket.h's connect to connectX until I could discuss with someone else who understands whats up.
