### PR TITLE
Use the right size on memset

### DIFF
--- a/ccspi.cpp
+++ b/ccspi.cpp
@@ -213,7 +213,7 @@ void SpiOpen(gcSpiHandleRx pfRxHandler)
   sSpiInformation.ulSpiState = eSPI_STATE_POWERUP;
 
   memset(spi_buffer, 0, sizeof(spi_buffer));
-  memset(wlan_tx_buffer, 0, sizeof(spi_buffer));
+  memset(wlan_tx_buffer, 0, sizeof(wlan_tx_buffer));
 
   sSpiInformation.SPIRxHandler      = pfRxHandler;
   sSpiInformation.usTxPacketLength  = 0;


### PR DESCRIPTION
[We](http://dropship.github.io/) were having issues with our cc3000 crashing when sending large amounts of UDP packets across the wire.  After tracing through the code, I found this `memset` which looks to be resetting `wlan_tx_buffer` with the incorrect size. 

Once this was changed, we were no longer plagued by crashing WiFi chips.
