### PR TITLE
rename socket.cpp/h to CC3000_socket.cpp/h

### DIFF
--- a/Adafruit_CC3000.cpp
+++ b/Adafruit_CC3000.cpp
@@ -29,7 +29,7 @@
 #include "utility/netapp.h"
 #include "utility/nvmem.h"
 #include "utility/security.h"
-#include "utility/socket.h"
+#include "utility/CC3000_socket.h"
 #include "utility/wlan.h"
 #include "utility/debug.h"
 #include "utility/sntp.h"

--- a/Adafruit_CC3000_Server.cpp
+++ b/Adafruit_CC3000_Server.cpp
@@ -14,7 +14,7 @@
 /**************************************************************************/
 #include "Adafruit_CC3000_Server.h"
 
-#include "utility/socket.h"
+#include "utility/CC3000_socket.h"
 
 #define CC3K_PRINTLN_F(text) CHECK_PRINTER { if(CC3KPrinter != NULL) { CC3KPrinter->println(F(text)); } }
 

--- a/examples/ChatServer/ChatServer.ino
+++ b/examples/ChatServer/ChatServer.ino
@@ -68,7 +68,7 @@
 #include <Adafruit_CC3000.h>
 #include <SPI.h>
 #include "utility/debug.h"
-#include "utility/socket.h"
+#include "utility/CC3000_socket.h"
 
 // These are the interrupt and control pins
 #define ADAFRUIT_CC3000_IRQ   3  // MUST be an interrupt pin!

--- a/examples/EchoServer/EchoServer.ino
+++ b/examples/EchoServer/EchoServer.ino
@@ -74,7 +74,7 @@
 #include <Adafruit_CC3000.h>
 #include <SPI.h>
 #include "utility/debug.h"
-#include "utility/socket.h"
+#include "utility/CC3000_socket.h"
 
 // These are the interrupt and control pins
 #define ADAFRUIT_CC3000_IRQ   3  // MUST be an interrupt pin!

--- a/examples/HTTPServer/HTTPServer.ino
+++ b/examples/HTTPServer/HTTPServer.ino
@@ -55,7 +55,7 @@
 #include <Adafruit_CC3000.h>
 #include <SPI.h>
 #include "utility/debug.h"
-#include "utility/socket.h"
+#include "utility/CC3000_socket.h"
 
 // These are the interrupt and control pins
 #define ADAFRUIT_CC3000_IRQ   3  // MUST be an interrupt pin!

--- a/utility/CC3000_socket.cpp
+++ b/utility/CC3000_socket.cpp
@@ -54,7 +54,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include "hci.h"
-#include "socket.h"
+#include "CC3000_socket.h"
 #include "evnt_handler.h"
 #include "netapp.h"
 #include "debug.h"

--- a/utility/CC3000_socket.h
+++ b/utility/CC3000_socket.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 *
-*  socket.h  - CC3000 Host Driver Implementation.
+*  CC3000_socket.h  - CC3000 Host Driver Implementation.
 *  Copyright (C) 2011 Texas Instruments Incorporated - http://www.ti.com/
 *
 * Adapted for use with the Arduino/AVR by KTOWN (Kevin Townsend) 
@@ -40,8 +40,8 @@
 *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *
 *****************************************************************************/
-#ifndef __SOCKET_H__
-#define __SOCKET_H__
+#ifndef __CC3000_SOCKET_H__
+#define __CC3000_SOCKET_H__
 
 #include "data_types.h"
 

--- a/utility/cc3000_common.cpp
+++ b/utility/cc3000_common.cpp
@@ -52,7 +52,7 @@
  *
  *****************************************************************************/
 #include "cc3000_common.h"
-#include "socket.h"
+#include "CC3000_socket.h"
 #include "wlan.h"
 #include "evnt_handler.h"
 #include "debug.h"

--- a/utility/evnt_handler.cpp
+++ b/utility/evnt_handler.cpp
@@ -56,7 +56,7 @@
 #include "hci.h"
 #include "evnt_handler.h"
 #include "wlan.h"
-#include "socket.h"
+#include "CC3000_socket.h"
 #include "netapp.h"
 #include "../ccspi.h"
 #include "debug.h"

--- a/utility/evnt_handler.h
+++ b/utility/evnt_handler.h
@@ -43,7 +43,7 @@
 #ifndef __EVENT_HANDLER_H__
 #define __EVENT_HANDLER_H__
 #include "hci.h"
-#include "socket.h"
+#include "CC3000_socket.h"
 
 //*****************************************************************************
 //

--- a/utility/netapp.cpp
+++ b/utility/netapp.cpp
@@ -43,7 +43,7 @@
 #include <string.h>
 #include "netapp.h"
 #include "hci.h"
-#include "socket.h"
+#include "CC3000_socket.h"
 #include "evnt_handler.h"
 #include "nvmem.h"
 

--- a/utility/nvmem.cpp
+++ b/utility/nvmem.cpp
@@ -58,7 +58,7 @@
 
 #include "nvmem.h"
 #include "hci.h"
-#include "socket.h"
+#include "CC3000_socket.h"
 #include "evnt_handler.h"
 #include "debug.h"
 

--- a/utility/sntp.h
+++ b/utility/sntp.h
@@ -272,8 +272,8 @@
 	#include "WProgram.h"
 #endif
 
-#include "utility/socket.h"
-#include "utility/netapp.h"
+#include "CC3000_socket.h"
+#include "netapp.h"
 
 //#define CLOCK_DEBUG
 //#define CLOCK_DEEP_DEBUG

--- a/utility/wlan.cpp
+++ b/utility/wlan.cpp
@@ -51,7 +51,7 @@
 #include "wlan.h"
 #include "hci.h"
 #include "../ccspi.h"
-#include "socket.h"
+#include "CC3000_socket.h"
 #include "nvmem.h"
 #include "security.h"
 #include "evnt_handler.h"


### PR DESCRIPTION
See [here](https://forums.adafruit.com/viewtopic.php?f=31&t=60840) for context.

Socket.cpp/h need to be renamed to CC3000_socket.cpp/h to avoid conflict with the Ethernet library.  This is a very safe change that I believe will help people avoid this problem in the future.

I also removed the unnecessary folder specifier from sntp.h
