### PR TITLE
Update GeoLocation.ino

### DIFF
--- a/examples/GeoLocation/GeoLocation.ino
+++ b/examples/GeoLocation/GeoLocation.ino
@@ -129,7 +129,7 @@ void setup(void) {
   client = cc3000.connectTCP(ip, 80);
   if(client.connected()) {
     Serial.print(F("connected.\r\nRequesting data..."));
-    client.print(F("GET /json/ HTTP/1.0\r\nConnection: close\r\n\r\n"));
+    client.print(F("GET /json/ HTTP/1.1\r\nHost: freegeoip.net\r\n\r\n"));
   } else {
     Serial.println(F("failed"));
     return;


### PR DESCRIPTION
Changes to freegeoip.net meant that this recently stopped working. Changing the format to be http 1.1 and having an explicit host name (as per the WebClient example) fixes the issue.
